### PR TITLE
fix: CODEOWNERS file syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 
 # DevOps
-* @devops
+* @southernlights-tech/devops


### PR DESCRIPTION
### Update CODEOWNERS for DevOps team

This PR updates the `CODEOWNERS` file to reflect the new GitHub team for the
DevOps group. The `@devops` entry has been replaced with
`@southernlights-tech/devops` to align with organizational team structures.
